### PR TITLE
Anticipate circulator switch on

### DIFF
--- a/src/okopilote/controller/controller.py
+++ b/src/okopilote/controller/controller.py
@@ -154,9 +154,7 @@ class Controller(threading.Thread):
             logger.error(errors[-1])
         for id_, r in self.roomset.rooms.items():
             if r.temp_deviation is None:
-                warnings.append(
-                    f"Room ''{id_}' does\'nt know its temperature deviation"
-                )
+                warnings.append(f"Room ''{id_}' does'nt know its temperature deviation")
 
         # Compute heat necessity
         self.cold_rooms = [

--- a/src/okopilote/controller/controller.py
+++ b/src/okopilote/controller/controller.py
@@ -59,6 +59,7 @@ class Controller(threading.Thread):
         self.boiler_gen_heat = None
         self.boiler_deliv_heat = None
         self.boiler_heat_avail = None
+        self.futur_circulator_state = None
         self.force_heat = False
         # Engine (boiler) starter
         self.starter = False
@@ -147,18 +148,14 @@ class Controller(threading.Thread):
 
         # Sync rooms
         try:
-            self.roomset.controller_sync(
-                temp_set_offset=self.set_offset, circulator_runs=self.boiler_deliv_heat
-            )
+            self.roomset.controller_sync(temp_set_offset=self.set_offset)
         except Exception as e:
             errors.append("Rooms sync: {}".format(e))
             logger.error(errors[-1])
         for id_, r in self.roomset.rooms.items():
             if r.temp_deviation is None:
                 warnings.append(
-                    ('Room "{}" does\'nt know its temperature ' + "deviation").format(
-                        id_
-                    )
+                    f"Room ''{id_}' does\'nt know its temperature deviation"
                 )
 
         # Compute heat necessity
@@ -188,6 +185,14 @@ class Controller(threading.Thread):
         else:
             self.worse_deviation = 0
             self.force_heat = False
+
+        # Advertise present or futur circulator state to rooms
+        self.futur_circulator_state = self.boiler_deliv_heat or self.force_heat
+        try:
+            self.roomset.controller_sync(circulator_runs=self.futur_circulator_state)
+        except Exception as e:
+            errors.append("Rooms sync: {}".format(e))
+            logger.error(errors[-1])
 
         # Apply the decision
         try:


### PR DESCRIPTION
Thermoelectric valves have delay to switch on/off. In this PR, the controller notifies rooms of a (futur) circulator switch on as soon as the it decides to force heating (instead of waiting that the circulator is actually running). In case the boiler needs time to heat water, this let time to normally-open valves to close, thus avoiding room over-heating